### PR TITLE
Don't cache files database

### DIFF
--- a/flexo/src/mirror_flexo.rs
+++ b/flexo/src/mirror_flexo.rs
@@ -564,7 +564,9 @@ impl Order for DownloadOrder {
     }
 
     fn is_cacheable(&self) -> bool {
-        !(self.filepath.to_str().ends_with(".db") || self.filepath.to_str().ends_with(".sig"))
+        !(self.filepath.to_str().ends_with(".db") ||
+          self.filepath.to_str().ends_with(".files") ||
+          self.filepath.to_str().ends_with(".sig"))
     }
 }
 


### PR DESCRIPTION
I use `pacman -F`, and suddenly got a message about the files signature being invalid.

After investigation, it turns out that flexo was caching `.files`:

```
Request served [NO PAYLOAD]: "core/os/x86_64/core.db"
Request served [NO PAYLOAD]: "extra/os/x86_64/extra.db"
Request served [NO PAYLOAD]: "community/os/x86_64/community.db"
Request "custom_repo/local/os/x86_64/local.db" will be served via unofficial repository "local"
Request served [NO PAYLOAD]: "custom_repo/local/os/x86_64/local.db"
Request served [CACHE HIT]: "core/os/x86_64/core.files"
Request served [NO PAYLOAD]: "core/os/x86_64/core.files.sig"
Request served [CACHE HIT]: "extra/os/x86_64/extra.files"
Request served [NO PAYLOAD]: "extra/os/x86_64/extra.files.sig"
Request served [CACHE HIT]: "community/os/x86_64/community.files"
Request served [NO PAYLOAD]: "community/os/x86_64/community.files.sig"
Request "custom_repo/local/os/x86_64/local.files" will be served via unofficial repository "local"
Request served [CACHE HIT]: "custom_repo/local/os/x86_64/local.files"
Request "custom_repo/local/os/x86_64/local.files.sig" will be served via unofficial repository "local"
Request served [NO PAYLOAD]: "custom_repo/local/os/x86_64/local.files.sig"
```

```
$ find /var/cache/flexo/pkg -name '*.db'
$ find /var/cache/flexo/pkg -name '*.sig'
$ find /var/cache/flexo/pkg -name '*.files'
/var/cache/flexo/pkg/community/os/x86_64/community.files
/var/cache/flexo/pkg/core/os/x86_64/core.files
/var/cache/flexo/pkg/extra/os/x86_64/extra.files
/var/cache/flexo/pkg/local/os/x86_64/local.files
```

Fix seemed really easy :grinning: 