### PR TITLE
Include remote URL in debug output

### DIFF
--- a/flexo/src/main.rs
+++ b/flexo/src/main.rs
@@ -747,6 +747,7 @@ fn serve_from_complete_file(
 }
 
 fn serve_via_redirect(uri: String, client_stream: &mut TcpStream) -> io::Result<()> {
+    debug!("Attempting to serve from {}", &uri);
     let header = redirect_header(&uri);
     client_stream.write_all(header.as_bytes())
 }


### PR DESCRIPTION
In spite of `RUST_LOG=debug` I found it very difficult to figure out why I was getting 404s for my `archzfs.db` updates. This line adds debug output to show the actual URL being requested, which helped me figure out the issue.