### PR TITLE
Fix example archzfs URL

### DIFF
--- a/flexo/conf/flexo.toml
+++ b/flexo/conf/flexo.toml
@@ -60,7 +60,7 @@ num_versions_retain = 3
 # You can list multiple repos by just adding multiple [[custom_repo]] entries.
 # Also adapt your pacman.conf to an entry like the following:
 # [archzfs]
-# Server = http://localhost:7878/custom_repo/archzfs/$repo/os/$arch
+# Server = http://localhost:7878/custom_repo/archzfs/$repo/$arch
 #
 # [[custom_repo]]
 #     name = "archzfs"


### PR DESCRIPTION
Archzfs URI doesn't have `os` in it.

Fixes https://github.com/nroi/flexo/issues/49