### PR TITLE
make DownloadOrder id an optional uuid non_cacheable_unique_id

### DIFF
--- a/flexo/src/main.rs
+++ b/flexo/src/main.rs
@@ -25,7 +25,6 @@ use humantime::format_duration;
 use libc::off64_t;
 #[cfg(test)]
 use tempfile::tempfile;
-use uuid::Uuid;
 
 use flexo::*;
 use mirror_flexo::*;
@@ -265,10 +264,7 @@ fn serve_request(
         serve_200_ok_empty(client_stream)?;
         Ok(PayloadOrigin::NoPayload)
     } else {
-        let order = DownloadOrder {
-            id: Uuid::new_v4(),
-            requested_path: request.path,
-        };
+        let order = DownloadOrder::new(request.path);
         debug!("Schedule new job");
         let result = job_context.lock().unwrap().try_schedule(order.clone(), custom_provider, request.resume_from);
         match result {


### PR DESCRIPTION
Hello,

I have discovered an issue when downloading the same package at the same time from two different clients when it is not yet cached.

The reason was that DownloadOrder id was unique for cacheable and uncacheable files.
When the current order is looked up in the list of orders it is never found because each order was unique.
This results is 2 simultaneous fetches of the file from the provider with different starting offsets in the destination.

This condition was never met
            let cached_size = if orders_in_progress.contains(&order) {
                debug!("order {:?} already in progress: nothing to do.", &order);
                return ScheduleOutcome::AlreadyInProgress;

This code was never executed
       ScheduleOutcome::AlreadyInProgress => {
                debug!("Job is already in progress");
                let path = order.filepath(&properties);
                let complete_filesize: u64 = try_complete_filesize_from_path(&path)?;
                let content_length = complete_filesize - request.resume_from.unwrap_or(0);
                let file = File::open(&path)?;
                serve_from_growing_file(file, content_length, request.resume_from, client_stream)?;
                Ok(PayloadOrigin::RemoteMirror)
            }

I made the id optional and renamed it to non_cacheable_unique_id.

I did consider writing a test bit the test rig does not seem to make this straightforward.

This is my first rust pullrequest so any advise most welcome.

I have attached a debug log

Thanks

Peter
[flexo.log](https://github.com/nroi/flexo/files/7861569/flexo.log)

