### PR TITLE
Make sendfile count min of bytes and max sendfile count

### DIFF
--- a/flexo/src/main.rs
+++ b/flexo/src/main.rs
@@ -909,8 +909,8 @@ fn send_payload<T>(source: &mut File, filesize: u64, bytes_sent: i64, receiver: 
     let size = unsafe {
         let mut offset = bytes_sent as off64_t;
         while (offset as u64) < filesize {
-            let count = cmp::min( filesize as usize - offset as usize, MAX_SENDFILE_COUNT as usize);
-            debug!("Sendfile count: {}",count);
+            let count = cmp::min(filesize as usize - offset as usize, MAX_SENDFILE_COUNT as usize);
+            debug!("Sendfile count: {}", count);
             let size: isize = libc::sendfile64(sfd, fd, &mut offset, count);
             if size == -1 {
                 return Err(std::io::Error::last_os_error());

--- a/flexo/src/main.rs
+++ b/flexo/src/main.rs
@@ -909,7 +909,7 @@ fn send_payload<T>(source: &mut File, filesize: u64, bytes_sent: i64, receiver: 
     let size = unsafe {
         let mut offset = bytes_sent as off64_t;
         while (offset as u64) < filesize {
-            let count = cmp::min(filesize as usize - offset as usize, MAX_SENDFILE_COUNT as usize);
+            let count = cmp::min(filesize as usize - offset as usize, MAX_SENDFILE_COUNT);
             debug!("Sendfile count: {}", count);
             let size: isize = libc::sendfile64(sfd, fd, &mut offset, count);
             if size == -1 {

--- a/flexo/src/main.rs
+++ b/flexo/src/main.rs
@@ -910,6 +910,7 @@ fn send_payload<T>(source: &mut File, filesize: u64, bytes_sent: i64, receiver: 
         let mut offset = bytes_sent as off64_t;
         while (offset as u64) < filesize {
             let count = cmp::min( filesize as usize - offset as usize, MAX_SENDFILE_COUNT as usize);
+            debug!("Sendfile count: {}",count);
             let size: isize = libc::sendfile64(sfd, fd, &mut offset, count);
             if size == -1 {
                 return Err(std::io::Error::last_os_error());

--- a/flexo/src/main.rs
+++ b/flexo/src/main.rs
@@ -17,6 +17,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
+use std::cmp;
 
 use crossbeam::channel::Receiver;
 use crossbeam::channel::RecvTimeoutError;
@@ -908,7 +909,8 @@ fn send_payload<T>(source: &mut File, filesize: u64, bytes_sent: i64, receiver: 
     let size = unsafe {
         let mut offset = bytes_sent as off64_t;
         while (offset as u64) < filesize {
-            let size: isize = libc::sendfile64(sfd, fd, &mut offset, MAX_SENDFILE_COUNT);
+            let count = cmp::min( filesize as usize - offset as usize, MAX_SENDFILE_COUNT as usize);
+            let size: isize = libc::sendfile64(sfd, fd, &mut offset, count);
             if size == -1 {
                 return Err(std::io::Error::last_os_error());
             }


### PR DESCRIPTION
There is an issue with sendfile returning EINVAL under linux 5.16 with zfs https://github.com/openzfs/zfs/issues/12971

As part of the diagnostics it was suggested that sendfile count should not be larger that the file to be sent.
It has not fixed the issue with sendfile and 5.16 under zfs but is perhaps more correct than the current code and should not trigger the following case should the kernel maintainers decide to implement this error.

```
       EOVERFLOW
              count is too large, the operation would result in exceeding the maximum size of either the input file or the output file.
```
[flexo.strace.5.15.txt](https://github.com/nroi/flexo/files/7874550/flexo.strace.5.15.txt)
[flexo.strace.5.16.txt](https://github.com/nroi/flexo/files/7874551/flexo.strace.5.16.txt)

